### PR TITLE
Solves specified key too long when migrating

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -13,7 +14,7 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        //
+        Schema::defaultStringLength(191); //Solved by increasing StringLength
     }
 
     /**


### PR DESCRIPTION
This solves the issue of specified key too long during migrations. 
![screen shot 2018-12-04 at 8 00 17 pm](https://user-images.githubusercontent.com/16350814/49466032-4e77df00-f7ff-11e8-97d1-1d855e19dbdf.png)
